### PR TITLE
Add naive exception handling for SymPy calls

### DIFF
--- a/flask/flaskapp/latex_solver.py
+++ b/flask/flaskapp/latex_solver.py
@@ -1,11 +1,21 @@
 from sympy.parsing.latex import parse_latex
+from sympy.parsing.latex import LaTeXParsingError
 from sympy import latex
 
 def solve(latex_styled):
     latex_formatted = format_latex(latex_styled)
-    expr = parse_latex(latex_formatted)
+    try:
+        expr = parse_latex(latex_formatted)
+    except LaTeXParsingError:
+        return "LaTeX parsing error"
 
-    return str(latex(expr.doit()))
+    try:
+        result = latex(expr.doit())
+        #This is super generic because sympy evaluation isn't trivial. 
+        # We'll probably want to switch away from using doit() in the future, for more control.
+    except Exception:
+        return "SymPy evaluation error"
+    return str(result)
 
 def format_latex(latex_styled):
     return r'{}'.format(latex_styled)


### PR DESCRIPTION
I just wrapped our calls to SymPy in some simple exception handling. I'm going to look at using more specific evaluators/[solvers](https://docs.sympy.org/latest/modules/solvers/solveset.html) instead of doit(), so we can get more specific exceptions (and maybe show solution steps).