### PR TITLE
Don't append a data URI to the b64 image

### DIFF
--- a/flask/flaskapp/mathpix.py
+++ b/flask/flaskapp/mathpix.py
@@ -12,7 +12,7 @@ class MathpixApiException(Exception):
     pass
 
 def submit_text(b64_image):
-    data = { "src": "data:image/png;base64," + b64_image }
+    data = { "src": b64_image }
     url = BASE_URL + "/text"
     response = requests.post(url, headers=HEADERS, json=data)
 


### PR DESCRIPTION
Instead, expect that the base64 image posted to the /solve-image and
/mathpix-ocr endpoints will already contain an appropriate header/URI.

@grantw99 you may want to wait to merge this to development until you've put it on the server and @jamesmann99 has changed the client-side behavior.